### PR TITLE
Support providing name in `make_catalog` fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,9 @@ See also [`ws`](#ws-fixture), [`env_or_skip`](#env_or_skip-fixture), [`sql_backe
 Create a catalog and return its info. Remove it after the test.
 Returns instance of [`CatalogInfo`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/catalog.html#databricks.sdk.service.catalog.CatalogInfo).
 
+Keyword Arguments:
+* `name` (str): The name of the catalog. Default is a random string.
+
 Usage:
 ```python
 def test_catalog_fixture(make_catalog, make_schema, make_table):

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -297,7 +297,7 @@ def make_catalog(
     ```
     """
 
-    def create(*, name: str = "") -> CatalogInfo:
+    def create(*, name: str | None = None) -> CatalogInfo:
         name = name or f"dummy_C{make_random(4)}".lower()
         catalog_info = ws.catalogs.create(name=name, properties={"RemoveAfter": watchdog_remove_after})
         if isinstance(catalog_info, Mock):

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -297,8 +297,8 @@ def make_catalog(
     ```
     """
 
-    def create() -> CatalogInfo:
-        name = f"dummy_C{make_random(4)}".lower()
+    def create(name: str = "") -> CatalogInfo:
+        name = name or f"dummy_C{make_random(4)}".lower()
         catalog_info = ws.catalogs.create(name=name, properties={"RemoveAfter": watchdog_remove_after})
         if isinstance(catalog_info, Mock):
             catalog_info.name = name

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -287,6 +287,9 @@ def make_catalog(
     Create a catalog and return its info. Remove it after the test.
     Returns instance of `databricks.sdk.service.catalog.CatalogInfo`.
 
+    Keyword Arguments:
+    * `name` (str): The name of the catalog. Default is a random string.
+
     Usage:
     ```python
     def test_catalog_fixture(make_catalog, make_schema, make_table):

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -297,7 +297,7 @@ def make_catalog(
     ```
     """
 
-    def create(name: str = "") -> CatalogInfo:
+    def create(*, name: str = "") -> CatalogInfo:
         name = name or f"dummy_C{make_random(4)}".lower()
         catalog_info = ws.catalogs.create(name=name, properties={"RemoveAfter": watchdog_remove_after})
         if isinstance(catalog_info, Mock):

--- a/src/databricks/labs/pytester/fixtures/unwrap.py
+++ b/src/databricks/labs/pytester/fixtures/unwrap.py
@@ -65,7 +65,7 @@ class CallContext:
 _GENERATORS = set[str]()
 
 
-def call_stateful(some: Callable[..., T], **kwargs) -> tuple[CallContext, T]:
+def call_stateful(some: Callable[..., Generator[Callable[..., T]]], **kwargs) -> tuple[CallContext, T]:
     # pylint: disable=too-complex
     ctx = CallContext()
     drains = []

--- a/tests/unit/fixtures/test_catalog.py
+++ b/tests/unit/fixtures/test_catalog.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 from databricks.sdk.service.catalog import TableInfo, TableType, DataSourceFormat, FunctionInfo
 
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
@@ -105,6 +107,11 @@ def test_make_catalog() -> None:
     ctx, info = call_stateful(make_catalog)
     ctx['ws'].catalogs.create.assert_called()  # can't specify call params accurately
     assert info.properties and info.properties.get("RemoveAfter", None)
+
+
+def test_make_catalog_creates_catalog_with_name() -> None:
+    ctx, info = call_stateful(make_catalog, name="test")
+    ctx['ws'].catalogs.create.assert_called_once_with(name="test", properties=ANY)
 
 
 def test_make_udf():

--- a/tests/unit/fixtures/test_catalog.py
+++ b/tests/unit/fixtures/test_catalog.py
@@ -101,7 +101,7 @@ def test_make_table_custom_schema():
     ]
 
 
-def test_make_catalog():
+def test_make_catalog() -> None:
     ctx, info = call_stateful(make_catalog)
     ctx['ws'].catalogs.create.assert_called()  # can't specify call params accurately
     assert info.properties and info.properties.get("RemoveAfter", None)

--- a/tests/unit/fixtures/test_catalog.py
+++ b/tests/unit/fixtures/test_catalog.py
@@ -105,7 +105,7 @@ def test_make_table_custom_schema():
 
 def test_make_catalog() -> None:
     ctx, info = call_stateful(make_catalog)
-    ctx['ws'].catalogs.create.assert_called()  # can't specify call params accurately
+    ctx['ws'].catalogs.create.assert_called_once()  # can't specify call params accurately
     assert info.properties and info.properties.get("RemoveAfter", None)
 
 

--- a/tests/unit/fixtures/test_catalog.py
+++ b/tests/unit/fixtures/test_catalog.py
@@ -110,7 +110,7 @@ def test_make_catalog() -> None:
 
 
 def test_make_catalog_creates_catalog_with_name() -> None:
-    ctx, info = call_stateful(make_catalog, name="test")
+    ctx, _ = call_stateful(make_catalog, name="test")
     ctx['ws'].catalogs.create.assert_called_once_with(name="test", properties=ANY)
 
 


### PR DESCRIPTION
## Changes
Add name parameter to `make_catalog` fixture.

### Tests

- [x] added unit tests
