### PR TITLE
store watchdog tags in storage credentials comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ def test_storage_credential(env_or_skip, make_storage_credential, make_random):
     )
 ```
 
-See also [`ws`](#ws-fixture).
+See also [`ws`](#ws-fixture), [`watchdog_remove_after`](#watchdog_remove_after-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]
@@ -1106,7 +1106,7 @@ See also [`ws`](#ws-fixture).
 ### `watchdog_remove_after` fixture
 Purge time for test objects, representing the (UTC-based) hour from which objects may be purged.
 
-See also [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_job`](#make_job-fixture), [`make_model`](#make_model-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_query`](#make_query-fixture), [`make_schema`](#make_schema-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_table`](#make_table-fixture), [`make_warehouse`](#make_warehouse-fixture), [`watchdog_purge_suffix`](#watchdog_purge_suffix-fixture).
+See also [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_job`](#make_job-fixture), [`make_model`](#make_model-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_query`](#make_query-fixture), [`make_schema`](#make_schema-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_storage_credential`](#make_storage_credential-fixture), [`make_table`](#make_table-fixture), [`make_warehouse`](#make_warehouse-fixture), [`watchdog_purge_suffix`](#watchdog_purge_suffix-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections.abc import Generator, Callable
 from unittest.mock import Mock
@@ -419,7 +420,7 @@ def make_storage_credential(ws, watchdog_remove_after) -> Generator[Callable[...
         aws_iam_role_arn: str = "",
         read_only=False,
     ) -> StorageCredentialInfo:
-        comment = {"RemoveAfter": watchdog_remove_after}
+        comment = json.dumps({"RemoveAfter": watchdog_remove_after})
         if aws_iam_role_arn != "":
             storage_credential = ws.storage_credentials.create(
                 credential_name,

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -386,7 +386,7 @@ def make_udf(
 
 
 @fixture
-def make_storage_credential(ws) -> Generator[Callable[..., StorageCredentialInfo], None, None]:
+def make_storage_credential(ws, watchdog_remove_after) -> Generator[Callable[..., StorageCredentialInfo], None, None]:
     """
     Create a storage credential and return its info. Remove it after the test. Returns instance of `databricks.sdk.service.catalog.StorageCredentialInfo`.
 
@@ -419,14 +419,15 @@ def make_storage_credential(ws) -> Generator[Callable[..., StorageCredentialInfo
         aws_iam_role_arn: str = "",
         read_only=False,
     ) -> StorageCredentialInfo:
+        comment = { "RemoveAfter": watchdog_remove_after }
         if aws_iam_role_arn != "":
             storage_credential = ws.storage_credentials.create(
-                credential_name, aws_iam_role=AwsIamRoleRequest(role_arn=aws_iam_role_arn), read_only=read_only
+                credential_name, aws_iam_role=AwsIamRoleRequest(role_arn=aws_iam_role_arn), read_only=read_only, comment=comment
             )
         else:
             azure_service_principal = AzureServicePrincipal(directory_id, application_id, client_secret)
             storage_credential = ws.storage_credentials.create(
-                credential_name, azure_service_principal=azure_service_principal, read_only=read_only
+                credential_name, azure_service_principal=azure_service_principal, read_only=read_only, comment=comment
             )
         return storage_credential
 

--- a/src/databricks/labs/pytester/fixtures/catalog.py
+++ b/src/databricks/labs/pytester/fixtures/catalog.py
@@ -419,10 +419,13 @@ def make_storage_credential(ws, watchdog_remove_after) -> Generator[Callable[...
         aws_iam_role_arn: str = "",
         read_only=False,
     ) -> StorageCredentialInfo:
-        comment = { "RemoveAfter": watchdog_remove_after }
+        comment = {"RemoveAfter": watchdog_remove_after}
         if aws_iam_role_arn != "":
             storage_credential = ws.storage_credentials.create(
-                credential_name, aws_iam_role=AwsIamRoleRequest(role_arn=aws_iam_role_arn), read_only=read_only, comment=comment
+                credential_name,
+                aws_iam_role=AwsIamRoleRequest(role_arn=aws_iam_role_arn),
+                read_only=read_only,
+                comment=comment,
             )
         else:
             azure_service_principal = AzureServicePrincipal(directory_id, application_id, client_secret)


### PR DESCRIPTION
## Changes
With our current implementation, the watchdog deletes all credentials blindly.
Since the watchdog can keep properly tagged credentials, this PR implements this tagging.

### Linked issues
See https://github.com/databrickslabs/watchdog/pull/63

### Tests
Not tested
