### PR TITLE
[FEATURE] Extend `make_job` to run `SparkPythonTask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ def test_workspace_operations(ws):
     assert len(clusters) >= 0
 ```
 
-See also [`log_workspace_link`](#log_workspace_link-fixture), [`make_alert_permissions`](#make_alert_permissions-fixture), [`make_authorization_permissions`](#make_authorization_permissions-fixture), [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_cluster_permissions`](#make_cluster_permissions-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_cluster_policy_permissions`](#make_cluster_policy_permissions-fixture), [`make_dashboard_permissions`](#make_dashboard_permissions-fixture), [`make_directory`](#make_directory-fixture), [`make_directory_permissions`](#make_directory_permissions-fixture), [`make_experiment`](#make_experiment-fixture), [`make_experiment_permissions`](#make_experiment_permissions-fixture), [`make_feature_table`](#make_feature_table-fixture), [`make_feature_table_permissions`](#make_feature_table_permissions-fixture), [`make_group`](#make_group-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_instance_pool_permissions`](#make_instance_pool_permissions-fixture), [`make_job`](#make_job-fixture), [`make_job_permissions`](#make_job_permissions-fixture), [`make_lakeview_dashboard_permissions`](#make_lakeview_dashboard_permissions-fixture), [`make_model`](#make_model-fixture), [`make_notebook`](#make_notebook-fixture), [`make_notebook_permissions`](#make_notebook_permissions-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_pipeline_permissions`](#make_pipeline_permissions-fixture), [`make_query`](#make_query-fixture), [`make_query_permissions`](#make_query_permissions-fixture), [`make_registered_model_permissions`](#make_registered_model_permissions-fixture), [`make_repo`](#make_repo-fixture), [`make_repo_permissions`](#make_repo_permissions-fixture), [`make_secret_scope`](#make_secret_scope-fixture), [`make_secret_scope_acl`](#make_secret_scope_acl-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_serving_endpoint_permissions`](#make_serving_endpoint_permissions-fixture), [`make_storage_credential`](#make_storage_credential-fixture), [`make_udf`](#make_udf-fixture), [`make_user`](#make_user-fixture), [`make_warehouse`](#make_warehouse-fixture), [`make_warehouse_permissions`](#make_warehouse_permissions-fixture), [`make_workspace_file_path_permissions`](#make_workspace_file_path_permissions-fixture), [`make_workspace_file_permissions`](#make_workspace_file_permissions-fixture), [`spark`](#spark-fixture), [`sql_backend`](#sql_backend-fixture), [`debug_env`](#debug_env-fixture), [`product_info`](#product_info-fixture).
+See also [`log_workspace_link`](#log_workspace_link-fixture), [`make_alert_permissions`](#make_alert_permissions-fixture), [`make_authorization_permissions`](#make_authorization_permissions-fixture), [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_cluster_permissions`](#make_cluster_permissions-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_cluster_policy_permissions`](#make_cluster_policy_permissions-fixture), [`make_dashboard_permissions`](#make_dashboard_permissions-fixture), [`make_directory`](#make_directory-fixture), [`make_directory_permissions`](#make_directory_permissions-fixture), [`make_experiment`](#make_experiment-fixture), [`make_experiment_permissions`](#make_experiment_permissions-fixture), [`make_feature_table`](#make_feature_table-fixture), [`make_feature_table_permissions`](#make_feature_table_permissions-fixture), [`make_group`](#make_group-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_instance_pool_permissions`](#make_instance_pool_permissions-fixture), [`make_job`](#make_job-fixture), [`make_job_permissions`](#make_job_permissions-fixture), [`make_lakeview_dashboard_permissions`](#make_lakeview_dashboard_permissions-fixture), [`make_model`](#make_model-fixture), [`make_notebook`](#make_notebook-fixture), [`make_notebook_permissions`](#make_notebook_permissions-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_pipeline_permissions`](#make_pipeline_permissions-fixture), [`make_query`](#make_query-fixture), [`make_query_permissions`](#make_query_permissions-fixture), [`make_registered_model_permissions`](#make_registered_model_permissions-fixture), [`make_repo`](#make_repo-fixture), [`make_repo_permissions`](#make_repo_permissions-fixture), [`make_secret_scope`](#make_secret_scope-fixture), [`make_secret_scope_acl`](#make_secret_scope_acl-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_serving_endpoint_permissions`](#make_serving_endpoint_permissions-fixture), [`make_storage_credential`](#make_storage_credential-fixture), [`make_udf`](#make_udf-fixture), [`make_user`](#make_user-fixture), [`make_warehouse`](#make_warehouse-fixture), [`make_warehouse_permissions`](#make_warehouse_permissions-fixture), [`make_workspace_file`](#make_workspace_file-fixture), [`make_workspace_file_path_permissions`](#make_workspace_file_path_permissions-fixture), [`make_workspace_file_permissions`](#make_workspace_file_permissions-fixture), [`spark`](#spark-fixture), [`sql_backend`](#sql_backend-fixture), [`debug_env`](#debug_env-fixture), [`product_info`](#product_info-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]
@@ -372,7 +372,7 @@ random_string = make_random(k=8)
 assert len(random_string) == 8
 ```
 
-See also [`make_acc_group`](#make_acc_group-fixture), [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_directory`](#make_directory-fixture), [`make_experiment`](#make_experiment-fixture), [`make_feature_table`](#make_feature_table-fixture), [`make_group`](#make_group-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_job`](#make_job-fixture), [`make_model`](#make_model-fixture), [`make_notebook`](#make_notebook-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_query`](#make_query-fixture), [`make_repo`](#make_repo-fixture), [`make_schema`](#make_schema-fixture), [`make_secret_scope`](#make_secret_scope-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_table`](#make_table-fixture), [`make_udf`](#make_udf-fixture), [`make_user`](#make_user-fixture), [`make_warehouse`](#make_warehouse-fixture).
+See also [`make_acc_group`](#make_acc_group-fixture), [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_directory`](#make_directory-fixture), [`make_experiment`](#make_experiment-fixture), [`make_feature_table`](#make_feature_table-fixture), [`make_group`](#make_group-fixture), [`make_instance_pool`](#make_instance_pool-fixture), [`make_job`](#make_job-fixture), [`make_model`](#make_model-fixture), [`make_notebook`](#make_notebook-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_query`](#make_query-fixture), [`make_repo`](#make_repo-fixture), [`make_schema`](#make_schema-fixture), [`make_secret_scope`](#make_secret_scope-fixture), [`make_serving_endpoint`](#make_serving_endpoint-fixture), [`make_table`](#make_table-fixture), [`make_udf`](#make_udf-fixture), [`make_user`](#make_user-fixture), [`make_warehouse`](#make_warehouse-fixture), [`make_workspace_file`](#make_workspace_file-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]
@@ -646,6 +646,32 @@ See also [`make_job`](#make_job-fixture), [`make_pipeline`](#make_pipeline-fixtu
 _No description yet._
 
 See also [`ws`](#ws-fixture).
+
+
+[[back to top](#python-testing-for-databricks)]
+
+### `make_workspace_file` fixture
+Returns a function to create Databricks workspace file and clean up after the test.
+The function returns [`os.PathLike` object](https://github.com/databrickslabs/blueprint?tab=readme-ov-file#python-native-pathlibpath-like-interfaces).
+
+Keyword arguments:
+* `path` (str, optional): The path of the file. Defaults to `dummy-*` notebook in current user's home folder.
+* `content` (str | bytes, optional): The content of the file. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
+* `language` ([`Language`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.Language), optional): The language of the notebook. Defaults to `Language.PYTHON`.
+* `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
+
+This example creates a notebook and verifies that the workspace path is an existing file with contents `print(1)`:
+```python
+def test_create_file(make_workspace_file):
+    workspace_file = make_workspace_file()
+    assert workspace_file.is_file()
+    assert "print(1)" in workspace_file.read_text()
+```
+
+TODO:
+Merge functionality with `make_notebook` if `WorkspacePath` supports creating notebooks.
+
+See also [`ws`](#ws-fixture), [`make_random`](#make_random-fixture), [`watchdog_purge_suffix`](#watchdog_purge_suffix-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]
@@ -1118,7 +1144,7 @@ See also [`make_catalog`](#make_catalog-fixture), [`make_cluster`](#make_cluster
 ### `watchdog_purge_suffix` fixture
 HEX-encoded purge time suffix for test objects.
 
-See also [`make_acc_group`](#make_acc_group-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_directory`](#make_directory-fixture), [`make_experiment`](#make_experiment-fixture), [`make_group`](#make_group-fixture), [`make_notebook`](#make_notebook-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_repo`](#make_repo-fixture), [`make_user`](#make_user-fixture), [`watchdog_remove_after`](#watchdog_remove_after-fixture).
+See also [`make_acc_group`](#make_acc_group-fixture), [`make_cluster_policy`](#make_cluster_policy-fixture), [`make_directory`](#make_directory-fixture), [`make_experiment`](#make_experiment-fixture), [`make_group`](#make_group-fixture), [`make_notebook`](#make_notebook-fixture), [`make_pipeline`](#make_pipeline-fixture), [`make_repo`](#make_repo-fixture), [`make_user`](#make_user-fixture), [`make_workspace_file`](#make_workspace_file-fixture), [`watchdog_remove_after`](#watchdog_remove_after-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]

--- a/README.md
+++ b/README.md
@@ -410,14 +410,17 @@ Create a Databricks job and clean it up after the test. Returns a function to cr
 a [`Job`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/jobs.html#databricks.sdk.service.jobs.Job) instance.
 
 Keyword Arguments:
-* `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
 * `name` (str, optional): The name of the job. If not provided, a random name will be generated.
-* `spark_conf` (dict, optional): The Spark configuration of the job.
+* `path` (str, optional): The path to the notebook or file used in the job. If not provided, a random notebook or file will be created
+* [DEPRECATED: Use `path` instead] `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
+* `content` (str, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
+* `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `NotebookTask` will be used.
+* `spark_conf` (dict, optional): The Spark configuration of the job. If not provided, Spark configuration is not explicitly set.
 * `libraries` (list, optional): The list of libraries to install on the job.
-* other arguments are passed to `WorkspaceClient.jobs.create` method.
-
-If no task argument is provided, a single task with a notebook task will be created, along with a disposable notebook.
-Latest Spark version and a single worker clusters will be used to run this ephemeral job.
+* `tags` (list[str], optional): A list of job tags. If not provided, no additional tags will be set on the job.
+* `tasks` (list[Task], optional): A list of job tags. If not provided, a single task with a notebook task will be
+   created, along with a disposable notebook. Latest Spark version and a single worker clusters will be used to run
+   this ephemeral job.
 
 Usage:
 ```python
@@ -621,10 +624,11 @@ The function returns [`os.PathLike` object](https://github.com/databrickslabs/bl
 
 Keyword arguments:
 * `path` (str, optional): The path of the notebook. Defaults to `dummy-*` notebook in current user's home folder.
-* `content` (typing.BinaryIO, optional): The content of the notebook. Defaults to `print(1)`.
+* `content` (str | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
 * `language` ([`Language`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.Language), optional): The language of the notebook. Defaults to `Language.PYTHON`.
-* `format` ([`ImportFormat`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.ImportFormat), optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
-* `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
+* `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
+* [DEPRECATED] `format` ([`ImportFormat`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.ImportFormat), optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
+* [DEPRECATED] `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
 
 This example creates a notebook and verifies that `print(1)` is in the content:
 ```python

--- a/README.md
+++ b/README.md
@@ -627,8 +627,8 @@ Keyword arguments:
 * `content` (str | bytes | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
 * `language` ([`Language`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.Language), optional): The language of the notebook. Defaults to `Language.PYTHON`.
 * `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
-* [DEPRECATED] `format` ([`ImportFormat`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.ImportFormat), optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
-* [DEPRECATED] `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
+* `format` ([`ImportFormat`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.ImportFormat), optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
+* `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
 
 This example creates a notebook and verifies that `print(1)` is in the content:
 ```python

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Keyword Arguments:
 * `name` (str, optional): The name of the job. If not provided, a random name will be generated.
 * `path` (str, optional): The path to the notebook or file used in the job. If not provided, a random notebook or file will be created
 * [DEPRECATED: Use `path` instead] `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
-* `content` (str, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
+* `content` (str | bytes, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
 * `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `NotebookTask` will be used.
 * `spark_conf` (dict, optional): The Spark configuration of the job. If not provided, Spark configuration is not explicitly set.
 * `libraries` (list, optional): The list of libraries to install on the job.
@@ -624,7 +624,7 @@ The function returns [`os.PathLike` object](https://github.com/databrickslabs/bl
 
 Keyword arguments:
 * `path` (str, optional): The path of the notebook. Defaults to `dummy-*` notebook in current user's home folder.
-* `content` (str | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
+* `content` (str | bytes | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
 * `language` ([`Language`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.Language), optional): The language of the notebook. Defaults to `Language.PYTHON`.
 * `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
 * [DEPRECATED] `format` ([`ImportFormat`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/workspace.html#databricks.sdk.service.workspace.ImportFormat), optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.

--- a/README.md
+++ b/README.md
@@ -414,7 +414,8 @@ Keyword Arguments:
 * `path` (str, optional): The path to the notebook or file used in the job. If not provided, a random notebook or file will be created
 * [DEPRECATED: Use `path` instead] `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
 * `content` (str | bytes, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
-* `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `NotebookTask` will be used.
+* `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `type[NotebookTask]` will be used.
+* `instance_pool_id` (str, optional): The instance pool id to add to the job cluster. If not provided, no instance pool will be used.
 * `spark_conf` (dict, optional): The Spark configuration of the job. If not provided, Spark configuration is not explicitly set.
 * `libraries` (list, optional): The list of libraries to install on the job.
 * `tags` (list[str], optional): A list of job tags. If not provided, no additional tags will be set on the job.
@@ -428,7 +429,7 @@ def test_job(make_job):
     logger.info(f"created {make_job()}")
 ```
 
-See also [`ws`](#ws-fixture), [`make_random`](#make_random-fixture), [`make_notebook`](#make_notebook-fixture), [`watchdog_remove_after`](#watchdog_remove_after-fixture).
+See also [`ws`](#ws-fixture), [`make_random`](#make_random-fixture), [`make_notebook`](#make_notebook-fixture), [`make_workspace_file`](#make_workspace_file-fixture), [`watchdog_remove_after`](#watchdog_remove_after-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]
@@ -671,7 +672,7 @@ def test_create_file(make_workspace_file):
 TODO:
 Merge functionality with `make_notebook` if `WorkspacePath` supports creating notebooks.
 
-See also [`ws`](#ws-fixture), [`make_random`](#make_random-fixture), [`watchdog_purge_suffix`](#watchdog_purge_suffix-fixture).
+See also [`make_job`](#make_job-fixture), [`ws`](#ws-fixture), [`make_random`](#make_random-fixture), [`watchdog_purge_suffix`](#watchdog_purge_suffix-fixture).
 
 
 [[back to top](#python-testing-for-databricks)]

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -209,7 +209,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             raise ValueError("The `path` and `content` parameters are exclusive.")
         if tasks and (path or content or spark_conf or libraries):
             raise ValueError(
-                "The `tasks` parameter is exclusive with the `path`, `content` `spark_conf` and `libraries` parameter."
+                "The `tasks` parameter is exclusive with the `path`, `content` `spark_conf` and `libraries` parameters."
             )
         path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -196,7 +196,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
         task_type: type[NotebookTask] | type[SparkPythonTask] = NotebookTask,
         spark_conf: dict[str, str] | None = None,
         libraries: list[Library] | None = None,
-        tags: list[dict[str, str]] | None = None,
+        tags: dict[str, str] | None = None,
         tasks: list[Task] | None = None,
     ) -> Job:
         if notebook_path is not None:
@@ -214,8 +214,8 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             )
         path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"
-        tags = tags or []
-        tags.append({"key": "RemoveAfter", "value": watchdog_remove_after})
+        tags = tags or {}
+        tags["RemoveAfter"] = tags.get("RemoveAfter", watchdog_remove_after)
         if not tasks:
             task = Task(
                 task_key=make_random(4),

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -207,9 +207,9 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             path = notebook_path
         if path and content:
             raise ValueError("The `path` and `content` parameters are exclusive.")
-        if tasks and (path or spark_conf or libraries):
+        if tasks and (path or content or spark_conf or libraries):
             raise ValueError(
-                "The `tasks` parameter is exclusive with the `path`, `spark_conf` and `libraries` parameter."
+                "The `tasks` parameter is exclusive with the `path`, `content` `spark_conf` and `libraries` parameter."
             )
         path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -204,7 +204,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
                 "when introducing workspace paths to python scripts.",
                 DeprecationWarning,
             )
-            path = path or notebook_path
+            path = notebook_path
         if path and content:
             raise ValueError("The `path` and `content` parameters are exclusive.")
         if tasks and (path or spark_conf or libraries):

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -241,7 +241,6 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             job = Job(settings=JobSettings(name=name, tasks=tasks, tags=tags))
         return job
 
-
     yield from factory("job", create, lambda item: ws.jobs.delete(item.job_id))
 
 

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -197,7 +197,7 @@ def make_job(
     ```
     """
 
-    def create(
+    def create(  # pylint: disable=too-many-arguments
         *,
         name: str | None = None,
         path: str | Path | None = None,

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -187,6 +187,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
         *,
         name: str | None = None,
         path: str | Path | None = None,
+        content: str | None = None,
         notebook_path: str | Path | None = None,
         spark_conf: dict[str, str] | None = None,
         libraries: list[Library] | None = None,
@@ -201,7 +202,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             )
             path = path or notebook_path
         else:
-            path = path or make_notebook()
+            path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"
         if not tasks:
             tasks = [

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -202,8 +202,9 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
                 DeprecationWarning,
             )
             path = path or notebook_path
-        else:
-            path = path or make_notebook(content=content)
+        if path and content:
+            raise ValueError("The `path` and `content` parameters are exclusive.")
+        path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"
         if not tasks:
             task = Task(

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -179,7 +179,7 @@ def make_job(
     * `path` (str, optional): The path to the notebook or file used in the job. If not provided, a random notebook or file will be created
     * [DEPRECATED: Use `path` instead] `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
     * `content` (str | bytes, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
-    * `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `NotebookTask` will be used.
+    * `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `type[NotebookTask]` will be used.
     * `spark_conf` (dict, optional): The Spark configuration of the job. If not provided, Spark configuration is not explicitly set.
     * `libraries` (list, optional): The list of libraries to install on the job.
     * `tags` (list[str], optional): A list of job tags. If not provided, no additional tags will be set on the job.

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -213,6 +213,8 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             )
         path = path or make_notebook(content=content)
         name = name or f"dummy-j{make_random(4)}"
+        tags = tags or []
+        tags.append({"key": "RemoveAfter", "value": watchdog_remove_after})
         if not tasks:
             task = Task(
                 task_key=make_random(4),
@@ -231,11 +233,6 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
             else:
                 task.notebook_task = NotebookTask(notebook_path=str(path))
             tasks = [task]
-        remove_after_tag = {"key": "RemoveAfter", "value": watchdog_remove_after}
-        if tags:
-            tags.append(remove_after_tag)
-        else:
-            tags = [remove_after_tag]
         job = ws.jobs.create(name=name, tasks=tasks, tags=tags)
         log_workspace_link(name, f"job/{job.job_id}", anchor=False)
         return ws.jobs.get(job.job_id)

--- a/src/databricks/labs/pytester/fixtures/compute.py
+++ b/src/databricks/labs/pytester/fixtures/compute.py
@@ -171,7 +171,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
     * `name` (str, optional): The name of the job. If not provided, a random name will be generated.
     * `path` (str, optional): The path to the notebook or file used in the job. If not provided, a random notebook or file will be created
     * [DEPRECATED: Use `path` instead] `notebook_path` (str, optional): The path to the notebook. If not provided, a random notebook will be created.
-    * `content` (str, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
+    * `content` (str | bytes, optional): The content of the notebook or file used in the job. If not provided, default content of `make_notebook` will be used.
     * `task_type` (type[NotebookTask] | type[SparkPythonTask], optional): The type of task. If not provides, `NotebookTask` will be used.
     * `spark_conf` (dict, optional): The Spark configuration of the job. If not provided, Spark configuration is not explicitly set.
     * `libraries` (list, optional): The list of libraries to install on the job.
@@ -192,7 +192,7 @@ def make_job(ws, make_random, make_notebook, log_workspace_link, watchdog_remove
         name: str | None = None,
         path: str | Path | None = None,
         notebook_path: str | Path | None = None,  # DEPRECATED
-        content: str | None = None,
+        content: str | bytes | None = None,
         task_type: type[NotebookTask] | type[SparkPythonTask] = NotebookTask,
         spark_conf: dict[str, str] | None = None,
         libraries: list[Library] | None = None,

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -48,10 +48,6 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[
         format: ImportFormat = ImportFormat.SOURCE,  # pylint:  disable=redefined-builtin
         overwrite: bool = False,
     ) -> WorkspacePath:
-        if path and (content or encoding or language):
-            raise ValueError(
-                "The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."
-            )
         encoding = encoding or _DEFAULT_ENCODING
         language = language or Language.PYTHON
         if language == Language.PYTHON:

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -71,7 +71,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[
 
 
 @fixture
-def make_file(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[..., WorkspacePath], None, None]:
+def make_workspace_file(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[..., WorkspacePath], None, None]:
     """
     Returns a function to create Databricks workspace file and clean up after the test.
     The function returns [`os.PathLike` object](https://github.com/databrickslabs/blueprint?tab=readme-ov-file#python-native-pathlibpath-like-interfaces).
@@ -84,10 +84,10 @@ def make_file(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[...,
 
     This example creates a notebook and verifies that the workspace path is an existing file with contents `print(1)`:
     ```python
-    def test_create_file(make_notebook):
-        workspace_path = make_file()
-        assert workspace_path.is_file()
-        assert "print(1)" in workspace_path.read_text()
+    def test_create_file(make_workspace_file):
+        workspace_file = make_workspace_file()
+        assert workspace_file.is_file()
+        assert "print(1)" in workspace_file.read_text()
     ```
 
     TODO:

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -28,8 +28,8 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[
     * `content` (str | bytes | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
     * `language` (`databricks.sdk.service.workspace.Language`, optional): The language of the notebook. Defaults to `Language.PYTHON`.
     * `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
-    * [DEPRECATED] `format` (`databricks.sdk.service.workspace.ImportFormat`, optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
-    * [DEPRECATED] `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
+    * `format` (`databricks.sdk.service.workspace.ImportFormat`, optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
+    * `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
 
     This example creates a notebook and verifies that `print(1)` is in the content:
     ```python

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -2,7 +2,7 @@ import io
 import logging
 import sys
 import warnings
-from collections.abc import Generator
+from collections.abc import Generator, Callable
 from pathlib import Path
 
 from pytest import fixture
@@ -18,7 +18,7 @@ _DEFAULT_ENCODING = sys.getdefaultencoding()
 
 
 @fixture
-def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[WorkspacePath, None, None]:
+def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[..., WorkspacePath], None, None]:
     """
     Returns a function to create Databricks Notebooks and clean them up after the test.
     The function returns [`os.PathLike` object](https://github.com/databrickslabs/blueprint?tab=readme-ov-file#python-native-pathlibpath-like-interfaces).

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -44,7 +44,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Workspace
         path: str | Path | None = None,
         content: str | io.BytesIO | None = None,
         language: Language = Language.PYTHON,
-        encoding=_DEFAULT_ENCODING,
+        encoding: str = _DEFAULT_ENCODING,
         **kwargs,
     ) -> WorkspacePath:
         if kwargs:

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -1,17 +1,20 @@
 import io
 import logging
+import sys
+import warnings
 from collections.abc import Generator
 from pathlib import Path
-import warnings
 
 from pytest import fixture
 from databricks.labs.blueprint.paths import WorkspacePath
-from databricks.sdk.service.workspace import Language, ImportFormat, RepoInfo
+from databricks.sdk.service.workspace import Language, RepoInfo
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.pytester.fixtures.baseline import factory
 
+
 logger = logging.getLogger(__name__)
+_DEFAULT_ENCODING = sys.getdefaultencoding()
 
 
 @fixture
@@ -24,6 +27,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Workspace
     * `path` (str, optional): The path of the notebook. Defaults to `dummy-*` notebook in current user's home folder.
     * `content` (str | io.BinaryIO, optional): The content of the notebook. Defaults to `print(1)` for Python and `SELECT 1` for SQL.
     * `language` (`databricks.sdk.service.workspace.Language`, optional): The language of the notebook. Defaults to `Language.PYTHON`.
+    * `encoding` (`str`, optional): The file encoding. Defaults to `sys.getdefaultencoding()`.
     * [DEPRECATED] `format` (`databricks.sdk.service.workspace.ImportFormat`, optional): The format of the notebook. Defaults to `ImportFormat.SOURCE`.
     * [DEPRECATED] `overwrite` (bool, optional): Whether to overwrite the notebook if it already exists. Defaults to `False`.
 
@@ -40,6 +44,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Workspace
         path: str | Path | None = None,
         content: str | io.BytesIO | None = None,
         language: Language = Language.PYTHON,
+        encoding=_DEFAULT_ENCODING,
         **kwargs,
     ) -> WorkspacePath:
         if kwargs:
@@ -57,7 +62,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Workspace
         if isinstance(content, io.BytesIO):
             workspace_path.write_bytes(content.read())
         else:
-            workspace_path.write_text(content or default_content)
+            workspace_path.write_text(content or default_content, encoding=encoding)
         logger.info(f"Created notebook: {workspace_path.as_uri()}")
         return workspace_path
 

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -72,7 +72,7 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[
         if isinstance(content, bytes):
             workspace_path.write_bytes(content)
             if isinstance(ws, Mock):  # For testing
-                ws.workspace.download.return_value = content
+                ws.workspace.download.return_value = io.BytesIO(content)
         else:
             workspace_path.write_text(content, encoding=encoding)
             if isinstance(ws, Mock):  # For testing

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -43,16 +43,22 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Workspace
         *,
         path: str | Path | None = None,
         content: str | io.BytesIO | None = None,
-        language: Language = Language.PYTHON,
-        encoding: str = _DEFAULT_ENCODING,
+        language: Language | None = None,
+        encoding: str | None = None,
         **kwargs,
     ) -> WorkspacePath:
         if kwargs:
             warnings.warn(f"Deprecated parameter(s): {kwargs}", DeprecationWarning)
-        if language == language.PYTHON:
+        if path and (content or encoding or language):
+            raise ValueError(
+                "The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."
+            )
+        encoding = encoding or _DEFAULT_ENCODING
+        language = language or Language.PYTHON
+        if language == Language.PYTHON:
             suffix = ".py"
             default_content = "print(1)"
-        elif language == language.SQL:
+        elif language == Language.SQL:
             suffix = ".sql"
             default_content = "SELECT 1"
         else:

--- a/src/databricks/labs/pytester/fixtures/notebooks.py
+++ b/src/databricks/labs/pytester/fixtures/notebooks.py
@@ -71,12 +71,11 @@ def make_notebook(ws, make_random, watchdog_purge_suffix) -> Generator[Callable[
             content = content.read()
         if isinstance(content, bytes):
             workspace_path.write_bytes(content)
-            if isinstance(ws, Mock):  # For testing
-                ws.workspace.download.return_value = io.BytesIO(content)
         else:
             workspace_path.write_text(content, encoding=encoding)
-            if isinstance(ws, Mock):  # For testing
-                ws.workspace.download.return_value = io.BytesIO(content.encode(encoding))
+            content = content.encode(encoding)  # For testing
+        if isinstance(ws, Mock):  # For testing
+            ws.workspace.download.return_value = io.BytesIO(content)
         logger.info(f"Created notebook: {workspace_path.as_uri()}")
         return workspace_path
 

--- a/src/databricks/labs/pytester/fixtures/plugin.py
+++ b/src/databricks/labs/pytester/fixtures/plugin.py
@@ -24,7 +24,7 @@ from databricks.labs.pytester.fixtures.catalog import (
     make_table,
     make_storage_credential,
 )
-from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
+from databricks.labs.pytester.fixtures.notebooks import make_directory, make_file, make_notebook, make_repo
 from databricks.labs.pytester.fixtures.permissions import (  # noqa
     make_cluster_policy_permissions,
     make_instance_pool_permissions,
@@ -81,6 +81,7 @@ __all__ = [
     'make_pipeline_permissions',
     'make_notebook',
     'make_notebook_permissions',
+    'make_file',
     'make_directory',
     'make_directory_permissions',
     'make_repo',

--- a/src/databricks/labs/pytester/fixtures/plugin.py
+++ b/src/databricks/labs/pytester/fixtures/plugin.py
@@ -24,7 +24,7 @@ from databricks.labs.pytester.fixtures.catalog import (
     make_table,
     make_storage_credential,
 )
-from databricks.labs.pytester.fixtures.notebooks import make_directory, make_file, make_notebook, make_repo
+from databricks.labs.pytester.fixtures.notebooks import make_directory, make_workspace_file, make_notebook, make_repo
 from databricks.labs.pytester.fixtures.permissions import (  # noqa
     make_cluster_policy_permissions,
     make_instance_pool_permissions,
@@ -81,7 +81,7 @@ __all__ = [
     'make_pipeline_permissions',
     'make_notebook',
     'make_notebook_permissions',
-    'make_file',
+    'make_workspace_file',
     'make_directory',
     'make_directory_permissions',
     'make_repo',

--- a/src/databricks/labs/pytester/fixtures/unwrap.py
+++ b/src/databricks/labs/pytester/fixtures/unwrap.py
@@ -27,7 +27,7 @@ class CallContext:
     def __init__(self):
         workspace_client = create_autospec(WorkspaceClient)
         workspace_client.current_user.me.return_value = iam.User(
-            user_name="user",
+            user_name="test-user",
             groups=[iam.ComplexValue(display="admins")],
         )
         workspace_client.get_workspace_id.return_value = 123456789

--- a/src/databricks/labs/pytester/fixtures/unwrap.py
+++ b/src/databricks/labs/pytester/fixtures/unwrap.py
@@ -30,6 +30,7 @@ class CallContext:
             user_name="test-user",
             groups=[iam.ComplexValue(display="admins")],
         )
+        workspace_client.config.host = "https://adb-12345679.10.azuredatabricks.net/"
         workspace_client.get_workspace_id.return_value = 123456789
         self._fixtures = {
             'sql_backend': MockBackend(),

--- a/src/databricks/labs/pytester/fixtures/unwrap.py
+++ b/src/databricks/labs/pytester/fixtures/unwrap.py
@@ -3,9 +3,11 @@
 import inspect
 from collections.abc import Callable, Generator
 from typing import TypeVar
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 from databricks.labs.lsql.backends import MockBackend
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import iam
 
 import databricks.labs.pytester.fixtures.plugin as P
 
@@ -23,8 +25,15 @@ def call_fixture(fixture_fn: Callable[..., T], *args, **kwargs) -> T:
 
 class CallContext:
     def __init__(self):
+        workspace_client = create_autospec(WorkspaceClient)
+        workspace_client.current_user.me.return_value = iam.User(
+            user_name="user",
+            groups=[iam.ComplexValue(display="admins")],
+        )
+        workspace_client.get_workspace_id.return_value = 123456789
         self._fixtures = {
             'sql_backend': MockBackend(),
+            'ws': workspace_client,
             'make_random': self.make_random,
             'env_or_skip': self.env_or_skip,
             'watchdog_remove_after': '2024091313',

--- a/tests/integration/fixtures/test_compute.py
+++ b/tests/integration/fixtures/test_compute.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from databricks.sdk.service.iam import PermissionLevel
+from databricks.sdk.service.jobs import RunResultState
+from databricks.sdk import WorkspaceClient
 
 from databricks.labs.pytester.fixtures.watchdog import TEST_RESOURCE_PURGE_TIMEOUT
 
@@ -20,8 +22,12 @@ def test_instance_pool(make_instance_pool):
     logger.info(f"created {make_instance_pool()}")
 
 
-def test_job(make_job):
-    logger.info(f"created {make_job()}")
+def test_job(ws: WorkspaceClient, make_job) -> None:
+    job = make_job()
+    run = ws.jobs.run_now(job.job_id)
+    ws.jobs.wait_get_run_job_terminated_or_skipped(run_id=run.run_id)
+    run_state = ws.jobs.get_run(run_id=run.run_id).state
+    assert run_state is not None and run_state.result_state == RunResultState.SUCCESS
 
 
 def test_pipeline(make_pipeline, make_pipeline_permissions, make_group):

--- a/tests/integration/fixtures/test_compute.py
+++ b/tests/integration/fixtures/test_compute.py
@@ -22,16 +22,16 @@ def test_instance_pool(make_instance_pool):
     logger.info(f"created {make_instance_pool()}")
 
 
-def test_job(ws: WorkspaceClient, make_job) -> None:
-    job = make_job()
+def test_job(ws: WorkspaceClient, make_job, env_or_skip) -> None:
+    job = make_job(instance_pool_id=env_or_skip("TEST_INSTANCE_POOL_ID"))
     run = ws.jobs.run_now(job.job_id)
     ws.jobs.wait_get_run_job_terminated_or_skipped(run_id=run.run_id)
     run_state = ws.jobs.get_run(run_id=run.run_id).state
     assert run_state is not None and run_state.result_state == RunResultState.SUCCESS
 
 
-def test_job_with_spark_python_task(ws: WorkspaceClient, make_job) -> None:
-    job = make_job(task_type=SparkPythonTask)
+def test_job_with_spark_python_task(ws: WorkspaceClient, make_job, env_or_skip) -> None:
+    job = make_job(task_type=SparkPythonTask, instance_pool_id=env_or_skip("TEST_INSTANCE_POOL_ID"))
     run = ws.jobs.run_now(job.job_id)
     ws.jobs.wait_get_run_job_terminated_or_skipped(run_id=run.run_id)
     run_state = ws.jobs.get_run(run_id=run.run_id).state

--- a/tests/integration/fixtures/test_notebooks.py
+++ b/tests/integration/fixtures/test_notebooks.py
@@ -9,10 +9,10 @@ def test_creates_some_notebook(make_notebook) -> None:
     assert "print(1)" in notebook.read_text()
 
 
-def test_creates_some_file(make_file) -> None:
-    workspace_path = make_file()
-    assert workspace_path.is_file()
-    assert "print(1)" in workspace_path.read_text()
+def test_creates_some_workspace_file(make_workspace_file) -> None:
+    workspace_file = make_workspace_file()
+    assert workspace_file.is_file()
+    assert "print(1)" in workspace_file.read_text()
 
 
 def test_creates_some_folder_with_a_notebook(make_directory, make_notebook):

--- a/tests/integration/fixtures/test_notebooks.py
+++ b/tests/integration/fixtures/test_notebooks.py
@@ -5,9 +5,14 @@ logger = logging.getLogger(__name__)
 
 def test_creates_some_notebook(make_notebook) -> None:
     notebook = make_notebook()
-    assert notebook.exists()
-    assert "print(1)" in notebook.read_text()
     assert notebook.is_notebook()
+    assert "print(1)" in notebook.read_text()
+
+
+def test_creates_some_file(make_file) -> None:
+    workspace_path = make_file()
+    assert workspace_path.is_file()
+    assert "print(1)" in workspace_path.read_text()
 
 
 def test_creates_some_folder_with_a_notebook(make_directory, make_notebook):

--- a/tests/integration/fixtures/test_notebooks.py
+++ b/tests/integration/fixtures/test_notebooks.py
@@ -5,7 +5,9 @@ logger = logging.getLogger(__name__)
 
 def test_creates_some_notebook(make_notebook) -> None:
     notebook = make_notebook()
+    assert notebook.exists()
     assert "print(1)" in notebook.read_text()
+    assert notebook.is_notebook()
 
 
 def test_creates_some_folder_with_a_notebook(make_directory, make_notebook):

--- a/tests/integration/fixtures/test_notebooks.py
+++ b/tests/integration/fixtures/test_notebooks.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def test_creates_some_notebook(make_notebook):
+def test_creates_some_notebook(make_notebook) -> None:
     notebook = make_notebook()
     assert "print(1)" in notebook.read_text()
 

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -29,11 +29,19 @@ def test_make_instance_pool_no_args():
     assert instance_pool is not None
 
 
-def test_make_job_no_args():
+def test_make_job_no_args() -> None:
     ctx, job = call_stateful(make_job)
     assert ctx is not None
     assert job is not None
+    assert job.settings.name == "dummy-jRANDOM"
+    assert job.settings.tags == [{"key": "RemoveAfter", "value": "2024091313"}]
     assert len(job.settings.tasks) == 1
+    assert job.settings.tasks[0].task_key == "RANDOM"
+    assert job.settings.tasks[0].description == "RANDOM"
+    assert job.settings.tasks[0].new_cluster.num_workers == 1
+    assert job.settings.tasks[0].new_cluster.spark_conf is None
+    assert job.settings.tasks[0].libraries is None
+    assert job.settings.tasks[0].timeout_seconds == 0
 
 
 def test_make_job_with_name() -> None:

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -86,6 +86,11 @@ def test_make_job_with_tags() -> None:
     assert job.settings.tags == [{"key": "test", "value": "test"}, {"key": "RemoveAfter", "value": "2024091313"}]
 
 
+def test_make_job_with_tasks() -> None:
+    _, job = call_stateful(make_job, tasks=["CustomTasks"])
+    assert job.settings.tasks == ["CustomTasks"]
+
+
 def test_make_pipeline_no_args():
     ctx, pipeline = call_stateful(make_pipeline)
     assert ctx is not None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -33,6 +33,11 @@ def test_make_job_no_args():
     assert job is not None
 
 
+def test_make_job_with_name() -> None:
+    ctx, job = call_stateful(make_job, name="test")
+    assert job.settings.name == "test"
+
+
 def test_make_pipeline_no_args():
     ctx, pipeline = call_stateful(make_pipeline)
     assert ctx is not None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -1,3 +1,4 @@
+from databricks.labs.blueprint.paths import WorkspacePath
 from databricks.sdk.service.jobs import Task
 
 from databricks.labs.pytester.fixtures.compute import (
@@ -54,6 +55,14 @@ def test_make_job_with_path() -> None:
     tasks: list[Task] = job.settings.tasks
     assert len(tasks) == 1
     assert tasks[0].notebook_task.notebook_path == "test.py"
+
+
+def test_make_job_with_content() -> None:
+    ctx, job = call_stateful(make_job, content="print(2)")
+    tasks = job.settings.tasks
+    assert len(tasks) == 1
+    workspace_path = WorkspacePath(ctx["ws"], tasks[0].notebook_task.notebook_path)
+    assert workspace_path.read_text() == "print(2)"
 
 
 def test_make_pipeline_no_args():

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -101,13 +101,13 @@ def test_make_job_with_tasks() -> None:
     assert job.settings.tasks == ["CustomTasks"]
 
 
-def test_make_pipeline_no_args():
+def test_make_pipeline_no_args() -> None:
     ctx, pipeline = call_stateful(make_pipeline)
     assert ctx is not None
     assert pipeline is not None
 
 
-def test_make_warehouse_no_args():
+def test_make_warehouse_no_args() -> None:
     ctx, warehouse = call_stateful(make_warehouse)
     assert ctx is not None
     assert warehouse is not None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -34,33 +34,41 @@ def test_make_job_no_args() -> None:
     ctx, job = call_stateful(make_job)
     assert ctx is not None
     assert job is not None
+    assert job.settings is not None
     assert job.settings.name == "dummy-jRANDOM"
     assert job.settings.tags == {"RemoveAfter": "2024091313"}
-    assert len(job.settings.tasks) == 1
-    assert job.settings.tasks[0].task_key == "RANDOM"
-    assert job.settings.tasks[0].description == "RANDOM"
-    assert job.settings.tasks[0].new_cluster.num_workers == 1
-    assert job.settings.tasks[0].new_cluster.spark_conf is None
-    assert job.settings.tasks[0].libraries is None
-    assert job.settings.tasks[0].timeout_seconds == 0
+    tasks = job.settings.tasks
+    assert isinstance(tasks, list) and len(tasks) == 1
+    assert tasks[0].task_key == "RANDOM"
+    assert tasks[0].description == "RANDOM"
+    assert tasks[0].new_cluster is not None
+    assert tasks[0].new_cluster.num_workers == 1
+    assert tasks[0].new_cluster.spark_conf is None
+    assert tasks[0].libraries is None
+    assert tasks[0].timeout_seconds == 0
 
 
 def test_make_job_with_name() -> None:
     _, job = call_stateful(make_job, name="test")
+    assert job.settings is not None
     assert job.settings.name == "test"
 
 
 def test_make_job_with_path() -> None:
     _, job = call_stateful(make_job, path="test.py")
+    assert job.settings is not None
     tasks = job.settings.tasks
-    assert len(tasks) == 1
+    assert isinstance(tasks, list) and len(tasks) == 1
+    assert tasks[0].notebook_task is not None
     assert tasks[0].notebook_task.notebook_path == "test.py"
 
 
 def test_make_job_with_content() -> None:
     ctx, job = call_stateful(make_job, content="print(2)")
+    assert job.settings is not None
     tasks = job.settings.tasks
-    assert len(tasks) == 1
+    assert isinstance(tasks, list) and len(tasks) == 1
+    assert tasks[0].notebook_task is not None
     workspace_path = WorkspacePath(ctx["ws"], tasks[0].notebook_task.notebook_path)
     assert not workspace_path.suffix  # Notebooks have no suffix
     assert workspace_path.read_text() == "print(2)"
@@ -68,8 +76,9 @@ def test_make_job_with_content() -> None:
 
 def test_make_job_with_spark_python_task() -> None:
     ctx, job = call_stateful(make_job, content="print(3)", task_type=SparkPythonTask)
+    assert job.settings is not None
     tasks = job.settings.tasks
-    assert len(tasks) == 1
+    assert isinstance(tasks, list) and len(tasks) == 1
     assert tasks[0].notebook_task is None
     assert tasks[0].spark_python_task is not None
     workspace_path = WorkspacePath(ctx["ws"], tasks[0].spark_python_task.python_file)
@@ -79,25 +88,31 @@ def test_make_job_with_spark_python_task() -> None:
 
 def test_make_job_with_instance_pool_id() -> None:
     _, job = call_stateful(make_job, instance_pool_id="test")
+    assert job.settings is not None
     tasks = job.settings.tasks
-    assert len(tasks) == 1
+    assert isinstance(tasks, list) and len(tasks) == 1
+    assert tasks[0].new_cluster is not None
     assert tasks[0].new_cluster.instance_pool_id == "test"
 
 
 def test_make_job_with_spark_conf() -> None:
     _, job = call_stateful(make_job, spark_conf={"value": "test"})
+    assert job.settings is not None
     tasks = job.settings.tasks
-    assert len(tasks) == 1
+    assert isinstance(tasks, list) and len(tasks) == 1
+    assert tasks[0].new_cluster is not None
     assert tasks[0].new_cluster.spark_conf == {"value": "test"}
 
 
 def test_make_job_with_tags() -> None:
     _, job = call_stateful(make_job, tags={"value": "test"})
+    assert job.settings is not None
     assert job.settings.tags == {"value": "test", "RemoveAfter": "2024091313"}
 
 
 def test_make_job_with_tasks() -> None:
     _, job = call_stateful(make_job, tasks=["CustomTasks"])
+    assert job.settings is not None
     assert job.settings.tasks == ["CustomTasks"]
 
 

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -1,5 +1,5 @@
 from databricks.labs.blueprint.paths import WorkspacePath
-from databricks.sdk.service.jobs import Task
+from databricks.sdk.service.jobs import Task, SparkPythonTask
 
 from databricks.labs.pytester.fixtures.compute import (
     make_cluster_policy,
@@ -63,6 +63,15 @@ def test_make_job_with_content() -> None:
     assert len(tasks) == 1
     workspace_path = WorkspacePath(ctx["ws"], tasks[0].notebook_task.notebook_path)
     assert workspace_path.read_text() == "print(2)"
+
+
+def test_make_job_with_spark_python_task() -> None:
+    ctx, job = call_stateful(make_job, path="test.py", task_type=SparkPythonTask)
+    tasks = job.settings.tasks
+    assert len(tasks) == 1
+    assert tasks[0].notebook_task is None
+    assert tasks[0].spark_python_task is not None
+    assert tasks[0].spark_python_task.python_file == "test.py"
 
 
 def test_make_pipeline_no_args():

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -74,6 +74,13 @@ def test_make_job_with_spark_python_task() -> None:
     assert tasks[0].spark_python_task.python_file == "test.py"
 
 
+def test_make_job_with_spark_conf() -> None:
+    _, job = call_stateful(make_job, spark_conf={"value": "test"})
+    tasks = job.settings.tasks
+    assert len(tasks) == 1
+    assert tasks[0].new_cluster.spark_conf == {"value": "test"}
+
+
 def test_make_pipeline_no_args():
     ctx, pipeline = call_stateful(make_pipeline)
     assert ctx is not None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -81,6 +81,11 @@ def test_make_job_with_spark_conf() -> None:
     assert tasks[0].new_cluster.spark_conf == {"value": "test"}
 
 
+def test_make_job_with_tags() -> None:
+    _, job = call_stateful(make_job, tags=[{"key": "test", "value": "test"}])
+    assert job.settings.tags == [{"key": "test", "value": "test"}, {"key": "RemoveAfter", "value": "2024091313"}]
+
+
 def test_make_pipeline_no_args():
     ctx, pipeline = call_stateful(make_pipeline)
     assert ctx is not None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -46,13 +46,13 @@ def test_make_job_no_args() -> None:
 
 
 def test_make_job_with_name() -> None:
-    ctx, job = call_stateful(make_job, name="test")
+    _, job = call_stateful(make_job, name="test")
     assert job.settings.name == "test"
 
 
 def test_make_job_with_path() -> None:
-    ctx, job = call_stateful(make_job, path="test.py")
-    tasks: list[Task] = job.settings.tasks
+    _, job = call_stateful(make_job, path="test.py")
+    tasks = job.settings.tasks
     assert len(tasks) == 1
     assert tasks[0].notebook_task.notebook_path == "test.py"
 
@@ -66,7 +66,7 @@ def test_make_job_with_content() -> None:
 
 
 def test_make_job_with_spark_python_task() -> None:
-    ctx, job = call_stateful(make_job, path="test.py", task_type=SparkPythonTask)
+    _, job = call_stateful(make_job, path="test.py", task_type=SparkPythonTask)
     tasks = job.settings.tasks
     assert len(tasks) == 1
     assert tasks[0].notebook_task is None

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -77,6 +77,13 @@ def test_make_job_with_spark_python_task() -> None:
     assert workspace_path.read_text() == "print(3)"
 
 
+def test_make_job_with_instance_pool_id() -> None:
+    _, job = call_stateful(make_job, instance_pool_id="test")
+    tasks = job.settings.tasks
+    assert len(tasks) == 1
+    assert tasks[0].new_cluster.instance_pool_id == "test"
+
+
 def test_make_job_with_spark_conf() -> None:
     _, job = call_stateful(make_job, spark_conf={"value": "test"})
     tasks = job.settings.tasks

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -35,7 +35,7 @@ def test_make_job_no_args() -> None:
     assert ctx is not None
     assert job is not None
     assert job.settings.name == "dummy-jRANDOM"
-    assert job.settings.tags == [{"key": "RemoveAfter", "value": "2024091313"}]
+    assert job.settings.tags == {"RemoveAfter": "2024091313"}
     assert len(job.settings.tasks) == 1
     assert job.settings.tasks[0].task_key == "RANDOM"
     assert job.settings.tasks[0].description == "RANDOM"
@@ -82,8 +82,8 @@ def test_make_job_with_spark_conf() -> None:
 
 
 def test_make_job_with_tags() -> None:
-    _, job = call_stateful(make_job, tags=[{"key": "test", "value": "test"}])
-    assert job.settings.tags == [{"key": "test", "value": "test"}, {"key": "RemoveAfter", "value": "2024091313"}]
+    _, job = call_stateful(make_job, tags={"value": "test"})
+    assert job.settings.tags == {"value": "test", "RemoveAfter": "2024091313"}
 
 
 def test_make_job_with_tasks() -> None:

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -31,6 +31,7 @@ def test_make_job_no_args():
     ctx, job = call_stateful(make_job)
     assert ctx is not None
     assert job is not None
+    assert len(job.settings.tasks) == 1
 
 
 def test_make_job_with_name() -> None:

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -62,16 +62,19 @@ def test_make_job_with_content() -> None:
     tasks = job.settings.tasks
     assert len(tasks) == 1
     workspace_path = WorkspacePath(ctx["ws"], tasks[0].notebook_task.notebook_path)
+    assert not workspace_path.suffix  # Notebooks have no suffix
     assert workspace_path.read_text() == "print(2)"
 
 
 def test_make_job_with_spark_python_task() -> None:
-    _, job = call_stateful(make_job, path="test.py", task_type=SparkPythonTask)
+    ctx, job = call_stateful(make_job, content="print(3)", task_type=SparkPythonTask)
     tasks = job.settings.tasks
     assert len(tasks) == 1
     assert tasks[0].notebook_task is None
     assert tasks[0].spark_python_task is not None
-    assert tasks[0].spark_python_task.python_file == "test.py"
+    workspace_path = WorkspacePath(ctx["ws"], tasks[0].spark_python_task.python_file)
+    assert workspace_path.suffix == ".py"  # Python files have suffix
+    assert workspace_path.read_text() == "print(3)"
 
 
 def test_make_job_with_spark_conf() -> None:

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -1,5 +1,5 @@
 from databricks.labs.blueprint.paths import WorkspacePath
-from databricks.sdk.service.jobs import Task, SparkPythonTask
+from databricks.sdk.service.jobs import SparkPythonTask
 
 from databricks.labs.pytester.fixtures.compute import (
     make_cluster_policy,

--- a/tests/unit/fixtures/test_compute.py
+++ b/tests/unit/fixtures/test_compute.py
@@ -1,3 +1,5 @@
+from databricks.sdk.service.jobs import Task
+
 from databricks.labs.pytester.fixtures.compute import (
     make_cluster_policy,
     make_cluster,
@@ -37,6 +39,13 @@ def test_make_job_no_args():
 def test_make_job_with_name() -> None:
     ctx, job = call_stateful(make_job, name="test")
     assert job.settings.name == "test"
+
+
+def test_make_job_with_path() -> None:
+    ctx, job = call_stateful(make_job, path="test.py")
+    tasks: list[Task] = job.settings.tasks
+    assert len(tasks) == 1
+    assert tasks[0].notebook_task.notebook_path == "test.py"
 
 
 def test_make_pipeline_no_args():

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,3 +1,5 @@
+import io
+
 from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
@@ -16,6 +18,11 @@ def test_make_notebook_with_path() -> None:
 def test_make_notebook_with_text_content() -> None:
     _, notebook = call_stateful(make_notebook, content="print(2)")
     assert notebook.read_text() == "print(2)"
+
+
+def test_make_notebook_with_bytes_content() -> None:
+    _, notebook = call_stateful(make_notebook, content=b"print(2)")
+    assert notebook.read_bytes() == b"print(2)"
 
 
 def test_make_directory_no_args():

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,9 +1,8 @@
 import io
 
-import pytest
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
+from databricks.labs.pytester.fixtures.notebooks import make_directory, make_file, make_notebook, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
 
@@ -42,6 +41,39 @@ def test_make_notebook_with_io_bytes_content() -> None:
 def test_make_notebook_with_sql_language() -> None:
     _, notebook = call_stateful(make_notebook, language=Language.SQL)
     assert notebook.read_text() == "SELECT 1"
+
+
+def test_make_file_no_args() -> None:
+    ctx, file = call_stateful(make_file)
+    assert ctx is not None
+    assert file is not None
+    # First part is the root slash
+    assert "/".join(file.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
+    assert file.suffix == ".py"
+    assert file.read_text() == "print(1)"
+    uri = file.as_uri()
+    assert uri == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
+
+
+def test_make_file_with_path() -> None:
+    _, file = call_stateful(make_file, path="test.py")
+    assert file.name == "test.py"
+
+
+def test_make_file_with_text_content() -> None:
+    _, file = call_stateful(make_file, content="print(2)")
+    assert file.read_text() == "print(2)"
+
+
+def test_make_file_with_bytes_content() -> None:
+    _, file = call_stateful(make_file, content=b"print(2)")
+    assert file.read_bytes() == b"print(2)"
+
+
+def test_make_file_with_sql_language() -> None:
+    _, file = call_stateful(make_file, language=Language.SQL)
+    assert file.suffix == ".sql"
+    assert file.read_text() == "SELECT 1"
 
 
 def test_make_directory_no_args():

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,5 +1,7 @@
 import io
 
+import pytest
+
 from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
@@ -13,6 +15,13 @@ def test_make_notebook_no_args() -> None:
     assert notebook.suffix == ".py"
     assert notebook.read_text() == "print(1)"
     assert notebook.as_uri() == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
+
+
+
+@pytest.mark.parametrize("argument", ["content", "encoding", "language"])
+def test_make_notebook_with_path_and_content_or_encoding_or_language_raises_value_error(argument: str) -> None:
+    with pytest.raises(ValueError, match="The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."):
+        call_stateful(make_notebook, path="test.py", **{argument: "foo"})
 
 
 def test_make_notebook_with_path() -> None:

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,6 +1,7 @@
 from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
+
 def test_make_notebook_no_args():
     ctx, notebook = call_stateful(make_notebook)
     assert ctx is not None

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -15,19 +15,24 @@ def test_make_notebook_no_args() -> None:
     assert "/".join(notebook.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
     assert notebook.suffix == ".py"
     assert notebook.read_text() == "print(1)"
-    assert notebook.as_uri() == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
-
+    assert (
+        notebook.as_uri()
+        == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
+    )
 
 
 @pytest.mark.parametrize("argument", ["content", "encoding", "language"])
 def test_make_notebook_with_path_and_content_or_encoding_or_language_raises_value_error(argument: str) -> None:
-    with pytest.raises(ValueError, match="The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."):
+    with pytest.raises(
+        ValueError, match="The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."
+    ):
         call_stateful(make_notebook, path="test.py", **{argument: "foo"})
 
 
 def test_make_notebook_with_path() -> None:
     _, notebook = call_stateful(make_notebook, path="test.py")
     assert notebook.name == "test.py"
+
 
 def test_make_notebook_with_text_content() -> None:
     _, notebook = call_stateful(make_notebook, content="print(2)")

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -4,10 +4,15 @@ from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_dire
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
 
-def test_make_notebook_no_args():
+def test_make_notebook_no_args() -> None:
     ctx, notebook = call_stateful(make_notebook)
     assert ctx is not None
     assert notebook is not None
+    # First part is the root slash
+    assert "/".join(notebook.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
+    assert notebook.suffix == ".py"
+    assert notebook.read_text() == "print(1)"
+    assert notebook.as_uri() == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
 
 
 def test_make_notebook_with_path() -> None:

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -28,7 +28,6 @@ def test_make_notebook_with_path() -> None:
     _, notebook = call_stateful(make_notebook, path="test.py")
     assert notebook.name == "test.py"
 
-
 def test_make_notebook_with_text_content() -> None:
     _, notebook = call_stateful(make_notebook, content="print(2)")
     assert notebook.read_text() == "print(2)"
@@ -36,6 +35,11 @@ def test_make_notebook_with_text_content() -> None:
 
 def test_make_notebook_with_bytes_content() -> None:
     _, notebook = call_stateful(make_notebook, content=b"print(2)")
+    assert notebook.read_bytes() == b"print(2)"
+
+
+def test_make_notebook_with_io_bytes_content() -> None:
+    _, notebook = call_stateful(make_notebook, content=io.BytesIO(b"print(2)"))
     assert notebook.read_bytes() == b"print(2)"
 
 

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -12,13 +12,11 @@ def test_make_notebook_no_args() -> None:
     assert ctx is not None
     assert notebook is not None
     # First part is the root slash
-    assert "/".join(notebook.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
-    assert notebook.suffix == ".py"
+    assert "/".join(notebook.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX"
+    assert not notebook.suffix
     assert notebook.read_text() == "print(1)"
-    assert (
-        notebook.as_uri()
-        == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
-    )
+    uri = notebook.as_uri()
+    assert uri == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX'
 
 
 @pytest.mark.parametrize("argument", ["content", "encoding", "language"])
@@ -51,7 +49,6 @@ def test_make_notebook_with_io_bytes_content() -> None:
 
 def test_make_notebook_with_sql_language() -> None:
     _, notebook = call_stateful(make_notebook, language=Language.SQL)
-    assert notebook.suffix == ".sql"
     assert notebook.read_text() == "SELECT 1"
 
 

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -13,6 +13,11 @@ def test_make_notebook_with_path() -> None:
     assert notebook.name == "test.py"
 
 
+def test_make_notebook_with_text_content() -> None:
+    _, notebook = call_stateful(make_notebook, content="print(2)")
+    assert notebook.read_text() == "print(2)"
+
+
 def test_make_directory_no_args():
     ctx, directory = call_stateful(make_directory)
     assert ctx is not None

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -2,7 +2,7 @@ import io
 
 from databricks.sdk.service.workspace import Language
 
-from databricks.labs.pytester.fixtures.notebooks import make_directory, make_file, make_notebook, make_repo
+from databricks.labs.pytester.fixtures.notebooks import make_directory, make_workspace_file, make_notebook, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
 
@@ -44,36 +44,36 @@ def test_make_notebook_with_sql_language() -> None:
 
 
 def test_make_file_no_args() -> None:
-    ctx, file = call_stateful(make_file)
+    ctx, workspace_file = call_stateful(make_workspace_file)
     assert ctx is not None
-    assert file is not None
+    assert workspace_file is not None
     # First part is the root slash
-    assert "/".join(file.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
-    assert file.suffix == ".py"
-    assert file.read_text() == "print(1)"
-    uri = file.as_uri()
+    assert "/".join(workspace_file.parts)[1:] == "/Users/test-user/dummy-RANDOM-XXXXX.py"
+    assert workspace_file.suffix == ".py"
+    assert workspace_file.read_text() == "print(1)"
+    uri = workspace_file.as_uri()
     assert uri == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX.py'
 
 
 def test_make_file_with_path() -> None:
-    _, file = call_stateful(make_file, path="test.py")
-    assert file.name == "test.py"
+    _, workspace_file = call_stateful(make_workspace_file, path="test.py")
+    assert workspace_file.name == "test.py"
 
 
 def test_make_file_with_text_content() -> None:
-    _, file = call_stateful(make_file, content="print(2)")
-    assert file.read_text() == "print(2)"
+    _, workspace_file = call_stateful(make_workspace_file, content="print(2)")
+    assert workspace_file.read_text() == "print(2)"
 
 
 def test_make_file_with_bytes_content() -> None:
-    _, file = call_stateful(make_file, content=b"print(2)")
-    assert file.read_bytes() == b"print(2)"
+    _, workspace_file = call_stateful(make_workspace_file, content=b"print(2)")
+    assert workspace_file.read_bytes() == b"print(2)"
 
 
 def test_make_file_with_sql_language() -> None:
-    _, file = call_stateful(make_file, language=Language.SQL)
-    assert file.suffix == ".sql"
-    assert file.read_text() == "SELECT 1"
+    _, workspace_file = call_stateful(make_workspace_file, language=Language.SQL)
+    assert workspace_file.suffix == ".sql"
+    assert workspace_file.read_text() == "SELECT 1"
 
 
 def test_make_directory_no_args():

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -26,7 +26,7 @@ def test_make_notebook_with_path_and_content_or_encoding_or_language_raises_valu
     with pytest.raises(
         ValueError, match="The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."
     ):
-        call_stateful(make_notebook, path="test.py", **{argument: "foo"})
+        call_stateful(make_notebook, path="test.py", **{argument: "foo"})  # type: ignore
 
 
 def test_make_notebook_with_path() -> None:

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -19,14 +19,6 @@ def test_make_notebook_no_args() -> None:
     assert uri == 'https://adb-12345679.10.azuredatabricks.net/#workspace/Users/test-user/dummy-RANDOM-XXXXX'
 
 
-@pytest.mark.parametrize("argument", ["content", "encoding", "language"])
-def test_make_notebook_with_path_and_content_or_encoding_or_language_raises_value_error(argument: str) -> None:
-    with pytest.raises(
-        ValueError, match="The `path` parameter is exclusive with the `content`, `language` and `encoding` parameters."
-    ):
-        call_stateful(make_notebook, path="test.py", **{argument: "foo"})  # type: ignore
-
-
 def test_make_notebook_with_path() -> None:
     _, notebook = call_stateful(make_notebook, path="test.py")
     assert notebook.name == "test.py"

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,6 +1,7 @@
 import io
 
 import pytest
+from databricks.sdk.service.workspace import Language
 
 from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
@@ -41,6 +42,12 @@ def test_make_notebook_with_bytes_content() -> None:
 def test_make_notebook_with_io_bytes_content() -> None:
     _, notebook = call_stateful(make_notebook, content=io.BytesIO(b"print(2)"))
     assert notebook.read_bytes() == b"print(2)"
+
+
+def test_make_notebook_with_sql_language() -> None:
+    _, notebook = call_stateful(make_notebook, language=Language.SQL)
+    assert notebook.suffix == ".sql"
+    assert notebook.read_text() == "SELECT 1"
 
 
 def test_make_directory_no_args():

--- a/tests/unit/fixtures/test_notebooks.py
+++ b/tests/unit/fixtures/test_notebooks.py
@@ -1,11 +1,15 @@
 from databricks.labs.pytester.fixtures.notebooks import make_notebook, make_directory, make_repo
 from databricks.labs.pytester.fixtures.unwrap import call_stateful
 
-
 def test_make_notebook_no_args():
     ctx, notebook = call_stateful(make_notebook)
     assert ctx is not None
     assert notebook is not None
+
+
+def test_make_notebook_with_path() -> None:
+    _, notebook = call_stateful(make_notebook, path="test.py")
+    assert notebook.name == "test.py"
 
 
 def test_make_directory_no_args():


### PR DESCRIPTION
## Changes
Extend `make_job` to run `SparkPythonTask` by:
- Add `make_workspace_file` fixture to create the Python file to run.
- Support SQL notebooks and files
- Add `task_type` to `make_job` to signal what type of task to run (notebook or python file)
- Add `instance_pool_id` to `make_job` for speeding up a job in integration tests by reusing an instance pool
- Add unit tests for changed fixtures
- Run jobs in integration tests

### Tests

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
