### PR TITLE
Fix incorrect parameter name in make_query() documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ See also [`ws`](#ws-fixture).
 Create a query and remove it after the test is done. Returns the [`LegacyQuery`](https://databricks-sdk-py.readthedocs.io/en/latest/dbdataclasses/sql.html#databricks.sdk.service.sql.LegacyQuery) object.
 
 Keyword Arguments:
-- `query`: The query to be stored. Default is `SELECT * FROM <newly created random table>`.
+- `sql_query`: The query to be stored. Default is `SELECT * FROM <newly created random table>`.
 
 Usage:
 ```python

--- a/src/databricks/labs/pytester/fixtures/redash.py
+++ b/src/databricks/labs/pytester/fixtures/redash.py
@@ -19,7 +19,7 @@ def make_query(
     Create a query and remove it after the test is done. Returns the `databricks.sdk.service.sql.LegacyQuery` object.
 
     Keyword Arguments:
-    - `query`: The query to be stored. Default is `SELECT * FROM <newly created random table>`.
+    - `sql_query`: The query to be stored. Default is `SELECT * FROM <newly created random table>`.
 
     Usage:
     ```python


### PR DESCRIPTION
## Changes

This PR fixes the documentation for the `make_query()` fixture: the argument name was incorrect.
