### PR TITLE
Set upper SDK limit to 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "databricks-sdk>=0.40,<0.42",
+    "databricks-sdk>=0.40,<1.0",
     "databricks-labs-lsql>=0.10",
     "pytest>=8.3",
 ]


### PR DESCRIPTION
## Changes

Set upper SDK limit to 1.0 as this is a library and the projects using pytester should set the right SDK limit
