### PR TITLE
Use string values for ServedModelInputWorkloadSize.SMALL as ServedMod…

### DIFF
--- a/src/databricks/labs/pytester/fixtures/ml.py
+++ b/src/databricks/labs/pytester/fixtures/ml.py
@@ -10,7 +10,6 @@ from databricks.sdk.service.serving import (
     EndpointPendingConfig,
     EndpointTag,
     ServedModelInput,
-    ServedModelInputWorkloadSize,
     ServedModelOutput,
     ServingEndpointDetailed,
 )
@@ -159,7 +158,7 @@ def make_serving_endpoint(ws, make_random, watchdog_remove_after):
             model_name=model_name,
             model_version=model_version,
             scale_to_zero_enabled=True,
-            workload_size=ServedModelInputWorkloadSize.SMALL,
+            workload_size="Small",
         )
         endpoint = ws.serving_endpoints.create(
             endpoint_name,
@@ -171,7 +170,7 @@ def make_serving_endpoint(ws, make_random, watchdog_remove_after):
                 model_name=model_name,
                 model_version=model_version,
                 scale_to_zero_enabled=True,
-                workload_size=ServedModelInputWorkloadSize.SMALL.value,
+                workload_size="Small",
             )
             endpoint = ServingEndpointDetailed(
                 name=endpoint_name,


### PR DESCRIPTION
The enum class `ServedModelInputWorkloadSize` [has been deprecated in databricks-sdk-py v0.51.0.](https://github.com/databrickslabs/pytester/issues/156#issue-3032061568), which causes the tests to fail. 

See [changelog](https://github.com/databricks/databricks-sdk-py/blob/516243949287e9668e59312a8701ea3eabc8daab/NEXT_CHANGELOG.md?plain=1#L56)

I updated the code to use the string value, "Small" instead of the deprecated Enum, ServedModelInputWorkloadSize

<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #156


Tested locally:
![image](https://github.com/user-attachments/assets/6997dcd2-d4c8-4b6e-8e13-51e1c31a8308)

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] verified on staging environment (screenshot attached)
