### PR TITLE
Compatibility fix for Databricks SDK 0.51

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "databricks-sdk>=0.40,<1.0",
+    "databricks-sdk>=0.51.0,<1.0",
     "databricks-labs-lsql>=0.10",
     "pytest>=8.3",
 ]

--- a/src/databricks/labs/pytester/fixtures/ml.py
+++ b/src/databricks/labs/pytester/fixtures/ml.py
@@ -10,7 +10,6 @@ from databricks.sdk.service.serving import (
     EndpointPendingConfig,
     EndpointTag,
     ServedModelInput,
-    ServedModelInputWorkloadSize,
     ServedModelOutput,
     ServingEndpointDetailed,
 )
@@ -159,7 +158,7 @@ def make_serving_endpoint(ws, make_random, watchdog_remove_after):
             model_name=model_name,
             model_version=model_version,
             scale_to_zero_enabled=True,
-            workload_size=ServedModelInputWorkloadSize.SMALL,
+            workload_size="Small",
         )
         endpoint = ws.serving_endpoints.create(
             endpoint_name,
@@ -171,7 +170,7 @@ def make_serving_endpoint(ws, make_random, watchdog_remove_after):
                 model_name=model_name,
                 model_version=model_version,
                 scale_to_zero_enabled=True,
-                workload_size=ServedModelInputWorkloadSize.SMALL.value,
+                workload_size="Small",
             )
             endpoint = ServingEndpointDetailed(
                 name=endpoint_name,


### PR DESCRIPTION
## Changes

[Databricks SDK 0.51](https://github.com/databricks/databricks-sdk-py/releases/tag/v0.51.0) included some breaking changes, including removal of an enumeration where a set of well-known string constants must now be used instead:
> Breaking] Removed large, medium and small enum values for databricks.sdk.service.serving.ServedModelInputWorkloadSize.

The change is not forward-compatible, so in addition to updating the fixture we need to bump the minimum-required SDK version because older versions expect the enum.

### Credits

This was earlier discovered and reported by @cornzyblack as #156.

### Linked issues

Resolves #156.
Supersedes #157.

This is also causing CI test failures on downstream projects including:

 - [databrickslabs/lsql](https://github.com/databrickslabs/lsql)
 - [databrickslabs/blueprint](https://github.com/databrickslabs/blueprint)

### Tests

- existing unit tests
