### PR TITLE
Update `call_fixture()` to work with pytest 8.4.

### DIFF
--- a/src/databricks/labs/pytester/fixtures/unwrap.py
+++ b/src/databricks/labs/pytester/fixtures/unwrap.py
@@ -20,12 +20,14 @@ T = TypeVar('T')
 # TODO: Investigate and fix this if possible, to avoid breakage in future pytest versions.
 # Potential solution: use `pytest.FixtureRequest` & `request.getfixturevalue()` to access fixtures.
 if pytest.version_tuple >= (8, 4):
+
     def call_fixture(fixture_fn: Callable[..., T], *args, **kwargs) -> T:
-        if  not hasattr(fixture_fn, "_get_wrapped_function"):
+        if not hasattr(fixture_fn, "_get_wrapped_function"):
             raise ValueError(f'{fixture_fn} is not a pytest fixture')
         accessor = getattr(fixture_fn, "_get_wrapped_function")
         wrapped = accessor()
         return wrapped(*args, **kwargs)
+
 else:
     # Older versions of pytest use a different mechanism to wrap fixtures.
     def call_fixture(fixture_fn: Callable[..., T], *args, **kwargs) -> T:


### PR DESCRIPTION
Internally the unit tests for pytester access pytest fixtures directly. This has been [deprecated since 4.x](https://docs.pytest.org/en/stable/deprecations.html#calling-fixtures-directly), but the project currently contains some workarounds (in `call_fixture()`) to do this anyway.

In pytest 8.4, the internals changed which breaks the way `call_fixture()` accesses the underlying fixture. This PR:

 - Updates `call_fixture()` minimally so that it also works with 8.4+.
 - Adds a marker that we should fix this properly.
 - Notes a promising direction for doing what we want in a supported manner.

Resolves #165.